### PR TITLE
Bump the required node version to the nearest non-vulnerable one

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "multer": "^1.1.0"
   },
   "engines": {
-    "node": "0.12.2"
+    "node": "~4.8.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is in response to the recent Constant Hashtable Seeds vulnerability